### PR TITLE
fix: remove invalid healthChecks from gateway-api-crds kustomization

### DIFF
--- a/clusters/selfhosted/gateway-api-crds.yaml
+++ b/clusters/selfhosted/gateway-api-crds.yaml
@@ -15,13 +15,3 @@ spec:
   timeout: 5m
   dependsOn:
     - name: gateway-api-source
-  healthChecks:
-    - apiVersion: apiextensions.k8s.io/v1
-      kind: CustomResourceDefinition
-      name: gatewayclasses.gateway.networking.k8s.io
-    - apiVersion: apiextensions.k8s.io/v1
-      kind: CustomResourceDefinition
-      name: gateways.gateway.networking.k8s.io
-    - apiVersion: apiextensions.k8s.io/v1
-      kind: CustomResourceDefinition
-      name: httproutes.gateway.networking.k8s.io


### PR DESCRIPTION
## Problem

The `gateway-api-crds` Kustomization is stuck in "Reconciliation in progress" state because it has health checks for CRDs that aren't in its inventory.

```
flux get kustomizations
gateway-api-crds   main@sha1:c58706df  False  Unknown  Reconciliation in progress
```

## Root Cause

The outer Kustomization (`clusters/selfhosted/gateway-api-crds.yaml`) deploys an inner Kustomization (`apps/infra/gateway-api-crds/crds-kustomization.yaml`) which actually installs the Gateway API CRDs.

Flux health checks only work for resources in a Kustomization's **own inventory**. Since the CRDs are managed by the inner Kustomization, the outer one can never pass the health checks.

## Fix

Remove the `healthChecks` from the outer Kustomization. The inner Kustomization already has `wait: true` which handles waiting for CRDs to be established.

## Test Plan

After merge:
```bash
flux get kustomizations
# gateway-api-crds should show Ready: True
```

Relates to: #91