### PR TITLE
fix: rename inner gateway-api-crds kustomization to avoid collision

### DIFF
--- a/apps/infra/gateway-api-crds/crds-kustomization.yaml
+++ b/apps/infra/gateway-api-crds/crds-kustomization.yaml
@@ -2,7 +2,7 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: gateway-api-crds
+  name: gateway-api-crds-installer
   namespace: flux-system
 spec:
   interval: 6h

--- a/clusters/selfhosted/gateway-api-crds.yaml
+++ b/clusters/selfhosted/gateway-api-crds.yaml
@@ -12,6 +12,11 @@ spec:
   path: ./apps/infra/gateway-api-crds
   prune: false
   wait: true
-  timeout: 5m
+  timeout: 10m
   dependsOn:
     - name: gateway-api-source
+  healthChecks:
+    - apiVersion: kustomize.toolkit.fluxcd.io/v1
+      kind: Kustomization
+      name: gateway-api-crds-installer
+      namespace: flux-system


### PR DESCRIPTION
## Problem

The `gateway-api-crds` Kustomization is stuck in "Reconciliation in progress" because of a **naming collision**:

- `clusters/selfhosted/gateway-api-crds.yaml` creates Flux Kustomization `gateway-api-crds`
- `apps/infra/gateway-api-crds/crds-kustomization.yaml` ALSO creates Flux Kustomization `gateway-api-crds`

The inner one overwrites the outer one's spec, causing confusion and the stuck state.

## Fix

1. **Rename inner Kustomization** from `gateway-api-crds` → `gateway-api-crds-installer`
2. **Add health check** for the inner Kustomization in the outer one
3. **Increase timeout** to 10m to allow for CRD installation time

## After Merge

```bash
# Force reconciliation
flux reconcile source git flux-system --kubeconfig ~/.kube/k3s-psychz-config
flux reconcile kustomization gateway-api-crds --kubeconfig ~/.kube/k3s-psychz-config

# Verify both kustomizations exist and are ready
flux get kustomizations | grep gateway
# Should show:
# gateway-api-crds           Ready
# gateway-api-crds-installer Ready
```

Relates to: #91