### PR TITLE
fix: add RBAC for Porkbun webhook to read credentials secret

### DIFF
--- a/apps/infra/cert-manager-config/kustomization.yaml
+++ b/apps/infra/cert-manager-config/kustomization.yaml
@@ -5,4 +5,5 @@ resources:
   - clusterissuer.yaml
   - clusterissuer-dns01.yaml
   - porkbun-webhook
+  - porkbun-webhook-rbac.yaml
   - porkbun-sealed-secret.yaml

--- a/apps/infra/cert-manager-config/porkbun-webhook-rbac.yaml
+++ b/apps/infra/cert-manager-config/porkbun-webhook-rbac.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: porkbun-webhook-secrets
+  namespace: cert-manager
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: ["porkbun-credentials"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: porkbun-webhook-secrets
+  namespace: cert-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: porkbun-webhook-secrets
+subjects:
+  - kind: ServiceAccount
+    name: porkbun-webhook
+    namespace: cert-manager


### PR DESCRIPTION
## Summary

- 🔐 Add Role and RoleBinding for Porkbun webhook to read `porkbun-credentials` secret
- 🐛 Fixes DNS-01 challenge failures blocking wildcard certificate issuance

## Problem

After PR #96 merged, the wildcard certificate failed to issue because the Porkbun webhook couldn't read the credentials:

```
secrets "porkbun-credentials" is forbidden: User
"system:serviceaccount:cert-manager:porkbun-webhook" cannot get
resource "secrets" in API group "" in namespace "cert-manager"
```

## Solution

Add minimal RBAC to grant read-only access to the specific secret:
- Role: `porkbun-webhook-secrets` (can only get `porkbun-credentials`)
- RoleBinding: Binds role to `porkbun-webhook` ServiceAccount

## Test plan

- [ ] Verify Role and RoleBinding created in cert-manager namespace
- [ ] Confirm DNS-01 challenges proceed without permission errors
- [ ] Watch certificate become Ready

```bash
# After merge, verify RBAC
kubectl -n cert-manager get role,rolebinding | grep porkbun

# Watch certificate status
kubectl -n envoy-gateway-system get certificate -w
```

## Related

- Fixes certificate issue discovered after #96
- Part of #91 (Envoy Gateway migration)