### PR TITLE
feat: switch to production wildcard certificate

### DIFF
--- a/apps/infra/envoy-gateway/gateway.yaml
+++ b/apps/infra/envoy-gateway/gateway.yaml
@@ -19,7 +19,7 @@ spec:
       tls:
         mode: Terminate
         certificateRefs:
-          - name: amajor-cloud-tls-staging
+          - name: amajor-cloud-tls
             kind: Secret
       allowedRoutes:
         namespaces:

--- a/apps/infra/envoy-gateway/kustomization.yaml
+++ b/apps/infra/envoy-gateway/kustomization.yaml
@@ -5,7 +5,7 @@ resources:
   - namespace.yaml
   - repository.yaml
   - helmrelease.yaml
-  - wildcard-certificate-staging.yaml
+  - wildcard-certificate.yaml
   - gatewayclass.yaml
   - gateway.yaml
   - http-redirect.yaml

--- a/apps/infra/envoy-gateway/wildcard-certificate.yaml
+++ b/apps/infra/envoy-gateway/wildcard-certificate.yaml
@@ -2,12 +2,12 @@
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: amajor-cloud-wildcard-staging
+  name: amajor-cloud-wildcard
   namespace: envoy-gateway-system
 spec:
-  secretName: amajor-cloud-tls-staging
+  secretName: amajor-cloud-tls
   issuerRef:
-    name: letsencrypt-staging-dns01
+    name: letsencrypt-production-dns01
     kind: ClusterIssuer
   dnsNames:
     - "amajor.cloud"


### PR DESCRIPTION
## Summary

- 🔐 Switch from staging to production Let's Encrypt wildcard certificate
- ✅ DNS-01 validation confirmed working with staging issuer

## Changes

| File | Change |
|------|--------|
| `wildcard-certificate.yaml` | Use `letsencrypt-production-dns01` issuer |
| `gateway.yaml` | Reference `amajor-cloud-tls` (production secret) |
| `kustomization.yaml` | Reference production cert file |

## Why This is Safe

The staging certificate was successfully issued, proving:
- ✅ Porkbun webhook can read credentials (RBAC working)
- ✅ DNS TXT records are created correctly
- ✅ Let's Encrypt can validate domain ownership
- ✅ Certificate is issued and stored in secret

## Test plan

- [ ] Verify production certificate is issued (`Ready=True`)
- [ ] Confirm certificate has valid Let's Encrypt chain (not staging)
- [ ] Check Gateway uses production cert for TLS termination

```bash
# After merge, watch certificate
kubectl -n envoy-gateway-system get certificate -w

# Verify production issuer
kubectl -n envoy-gateway-system get secret amajor-cloud-tls -o jsonpath='{.data.tls\.crt}' | \
  base64 -d | openssl x509 -noout -issuer
# Expected: issuer=C=US, O=Let's Encrypt, CN=R10 (or similar)
```

## Related

- Part of #91 (Envoy Gateway migration)
- Follows successful staging validation in #96, #97