### PR TITLE
feat: deploy SeaweedFS S3 object storage

### DIFF
--- a/apps/base/seaweedfs/helmrelease.yaml
+++ b/apps/base/seaweedfs/helmrelease.yaml
@@ -1,0 +1,108 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: seaweedfs
+  namespace: seaweedfs
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: seaweedfs
+      version: '4.17.0'
+      sourceRef:
+        kind: HelmRepository
+        name: seaweedfs
+        namespace: seaweedfs
+      interval: 12h
+  install:
+    createNamespace: false
+    timeout: 10m
+    remediation:
+      retries: 3
+  upgrade:
+    timeout: 10m
+    remediation:
+      retries: 3
+  values:
+    global:
+      imageName: chrislusf/seaweedfs@sha256:94b8ef37a1e98004868bab705eb93b43156ee0a8ebbfcbbe73c747c86e8c2366
+
+    master:
+      affinity: ""
+      defaultReplication: "000"
+      data:
+        type: "persistentVolumeClaim"
+        size: "1Gi"
+        storageClass: "local-path"
+      logs:
+        type: "emptyDir"
+      resources:
+        requests:
+          cpu: 50m
+          memory: 64Mi
+        limits:
+          cpu: 250m
+          memory: 256Mi
+
+    volume:
+      affinity: ""
+      dataDirs:
+        - name: data1
+          type: "persistentVolumeClaim"
+          size: "15Gi"
+          storageClass: "local-path"
+          maxVolumes: 0
+      idx: {}
+      logs:
+        type: "emptyDir"
+      resources:
+        requests:
+          cpu: 100m
+          memory: 128Mi
+        limits:
+          cpu: 500m
+          memory: 512Mi
+
+    filer:
+      affinity: ""
+      data:
+        type: "persistentVolumeClaim"
+        size: "2Gi"
+        storageClass: "local-path"
+      logs:
+        type: "emptyDir"
+      s3:
+        enabled: false
+      resources:
+        requests:
+          cpu: 100m
+          memory: 128Mi
+        limits:
+          cpu: 500m
+          memory: 512Mi
+      extraEnvironmentVars:
+        WEED_LEVELDB2_ENABLED: "true"
+        WEED_FILER_OPTIONS_RECURSIVE_DELETE: "false"
+        WEED_FILER_BUCKETS_FOLDER: "/buckets"
+
+    s3:
+      enabled: true
+      port: 8333
+      enableAuth: true
+      existingConfigSecret: seaweedfs-s3-credentials
+      resources:
+        requests:
+          cpu: 50m
+          memory: 64Mi
+        limits:
+          cpu: 250m
+          memory: 256Mi
+      logs:
+        type: "emptyDir"
+
+    sftp:
+      enabled: false
+
+    admin:
+      enabled: false

--- a/apps/base/seaweedfs/httproute.yaml
+++ b/apps/base/seaweedfs/httproute.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: seaweedfs-s3
+  namespace: seaweedfs
+spec:
+  parentRefs:
+    - name: amajor-cloud-gateway
+      namespace: envoy-gateway-system
+  hostnames:
+    - s3.amajor.cloud
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: seaweedfs-s3
+          port: 8333

--- a/apps/base/seaweedfs/kustomization.yaml
+++ b/apps/base/seaweedfs/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - s3-credentials-sealed-secret.yaml

--- a/apps/base/seaweedfs/kustomization.yaml
+++ b/apps/base/seaweedfs/kustomization.yaml
@@ -4,3 +4,6 @@ kind: Kustomization
 resources:
   - namespace.yaml
   - s3-credentials-sealed-secret.yaml
+  - repository.yaml
+  - helmrelease.yaml
+  - httproute.yaml

--- a/apps/base/seaweedfs/namespace.yaml
+++ b/apps/base/seaweedfs/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: seaweedfs

--- a/apps/base/seaweedfs/repository.yaml
+++ b/apps/base/seaweedfs/repository.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: seaweedfs
+  namespace: seaweedfs
+spec:
+  interval: 24h
+  url: https://seaweedfs.github.io/seaweedfs/helm

--- a/apps/base/seaweedfs/s3-credentials-sealed-secret.yaml
+++ b/apps/base/seaweedfs/s3-credentials-sealed-secret.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: seaweedfs-s3-credentials
+  namespace: seaweedfs
+spec:
+  encryptedData:
+    seaweedfs_s3_config: AgBAEWEL8SkBQska1OrGmTYcyfxpXLco2V6YpnrFearwz2qCoG90ZOytoS0Lt6SAmut65+fhN2GVK2jXSJkkBjLO668SBS9Fz8YCOv26p9q47vvxMYgE/TextV3zGjwMzfdPxT7g1YzVslG4D6WfGXdATS1QM2xcfxs9ApvBcEnkyPz5K5e3O/uQObCc1MWHFoclPgCsuIQeSsxufAARTUqSi+0hPwFf4/6Ij05UVTbQ34PLDZC2ABjR7GeYwUTtda8/qxyiLPKrEcKyDqVWBPLe7A52IAM6b9nvUhKvYyPlLUXZnCgd7eIywdFINrlvCswQCRU+fwJ0A0L5j+DZr1Bxg1xZV6ygk4hVak3A13xLVefSH/Jpd8dajztE2Zl9CR+monJdFtH+4JUDzEeYeTrAzsChSsBEmM+wM/WK3Qf+aCFRK2CKVvWcr/GOZ3bMe+LLDvrQPfwcUVenpX5KsofjDRG0cX+vJjT8VYcapJx5YhVaSe5EwzTBV9rtq5aKJp6/5x/7CyXQojsWd9ZQmV+NNq29ZW+WLn4VDgluY+exEtmrWqBjKVzWQ2IDGysBQg1+gNTDG2/BRSXQwEDAKW8T+X3Z8s73ssVFXEFYBwDpDy6qi4avlydW8yISVJrEIflIWIQqM3QtS3JS8525OukcUfG6ffVrYB3tJYCKEsd9hmNpWTGutlkyEIm55p28uPHt+Lothjo6TLl0xKtIqSMmTeG9v58TWpbfLQWPffJ4TSRkM0BGea+Us/ZW0mx3KDBkV34R0dVQfws3Yvf6Zp1zekrvjmuqtm5eXL12RpPWOvovrcL9+/cNqBTQL3KRqBECL0K4QCz8+GCHoJ0TJ19Z+4tQjIAf4rwIvt+e81oKEdZ5cmoUdxm6LqGp85DvxlTsBabiBaacX85t70T6z6DNTkelwp6EQja6K3mSWW96DtZ7uD9zkUUblqBDSblyLDf1OokhGxuhtpC0iJ9sP/aD6b8Z/WvPr/Y9Dr0c1cX8dj8Pqr5LweksjXWOhI++FmEzLZELtHaY97bw83U4ggR9WvrNtF+1oteiyWPAx266arLS1MIt/2Xg0L4FWEELSYU=
+  template:
+    metadata:
+      name: seaweedfs-s3-credentials
+      namespace: seaweedfs
+    type: Opaque

--- a/apps/infra/envoy-gateway/reference-grants.yaml
+++ b/apps/infra/envoy-gateway/reference-grants.yaml
@@ -42,3 +42,17 @@ spec:
   to:
     - group: gateway.networking.k8s.io
       kind: Gateway
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: allow-seaweedfs
+  namespace: envoy-gateway-system
+spec:
+  from:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      namespace: seaweedfs
+  to:
+    - group: gateway.networking.k8s.io
+      kind: Gateway


### PR DESCRIPTION
## Summary
Deploys SeaweedFS as S3-compatible object storage on single-node K3s cluster.

## Changes
- SeaweedFS HelmRelease (master, volume, filer, S3 gateway)
- S3 endpoint exposed at https://s3.amajor.cloud
- SealedSecret for S3 credentials
- ReferenceGrant for cross-namespace routing

## S3 Credentials
Credentials were printed to the terminal during SealedSecret generation. They are NOT stored in the repo. If lost, regenerate by creating a new SealedSecret.

## Post-Merge Verification
After merging, verify with:
```bash
export KUBECONFIG=~/.kube/k3s-psychz-config
flux reconcile kustomization apps
kubectl get pods -n seaweedfs
curl -sk https://s3.amajor.cloud/status
```

## Notes
- Single-node setup (no replication)
- 15Gi volume storage via local-path PVC
- MinIO is dead (archived Feb 2026), SeaweedFS is the replacement